### PR TITLE
Headless sharing and X11 screen id on 0.29.1

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -25,7 +25,9 @@ wayland-csd-adwaita-notitle = ["winit/wayland-csd-adwaita-notitle"]
 
 [dependencies]
 once_cell = "1.13"
-winit = { version = "0.27.1", default-features = false }
+# Patch needed to make WindowBuilder platform-specific info public for X11 screen
+# https://github.com/tonarino/winit/pull/2
+winit = { version = "0.27.5", git = "https://github.com/tonarino/winit", branch = "fix-and-publish-x11-screen-id", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 glutin_egl_sys = { version = "0.1.6", path = "../glutin_egl_sys" }

--- a/glutin/src/platform_impl/macos/mod.rs
+++ b/glutin/src/platform_impl/macos/mod.rs
@@ -151,6 +151,8 @@ impl Context {
     ) -> Result<Self, CreationError> {
         let gl_profile = helpers::get_gl_profile(gl_attr, pf_reqs)?;
         let attributes = helpers::build_nsattributes(pf_reqs, gl_profile)?;
+        let share_ctx = gl_attr.sharing.map_or(nil, |c| *c.get_id());
+
         let context = unsafe {
             let pixelformat = NSOpenGLPixelFormat::alloc(nil).initWithAttributes_(&attributes);
             if pixelformat == nil {
@@ -158,8 +160,10 @@ impl Context {
                     "Could not create the pixel format".to_string(),
                 ));
             }
+
             let context =
-                NSOpenGLContext::alloc(nil).initWithFormat_shareContext_(pixelformat, nil);
+                NSOpenGLContext::alloc(nil).initWithFormat_shareContext_(pixelformat, share_ctx);
+
             if context == nil {
                 return Err(CreationError::OsError(
                     "Could not create the rendering context".to_string(),

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -456,7 +456,9 @@ impl Context {
         };
 
         // Get the screen_id for the window being built.
-        let screen_id = unsafe { (xconn.xlib.XDefaultScreen)(xconn.display) };
+        let screen_id = wb.platform_specific.screen_id.unwrap_or_else(|| {
+            unsafe { (xconn.xlib.XDefaultScreen)(xconn.display) }
+        });
 
         let mut builder_glx_u = None;
         let mut builder_egl_u = None;


### PR DESCRIPTION
PR just for documentation of patches used. Relates to https://github.com/tonarino/portal/pull/2741